### PR TITLE
Migrate code to Move 2024

### DIFF
--- a/satoshi_flip/Move.toml
+++ b/satoshi_flip/Move.toml
@@ -1,6 +1,7 @@
 [package]
 name = "satoshi_flip"
 version = "0.0.1"
+edition = "2024.beta"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }

--- a/satoshi_flip/sources/house_data.move
+++ b/satoshi_flip/sources/house_data.move
@@ -87,27 +87,27 @@ module satoshi_flip::house_data {
     /// not being able to participate in any more games.
     public fun withdraw(house_data: &mut HouseData, ctx: &mut TxContext) {
         // Only the house address can withdraw funds.
-        assert!(ctx.sender() == house(house_data), ECallerNotHouse);
+        assert!(ctx.sender() == house_data.house(), ECallerNotHouse);
 
         let total_balance = balance(house_data);
         let coin = coin::take(&mut house_data.balance, total_balance, ctx);
-        transfer::public_transfer(coin, house(house_data));
+        transfer::public_transfer(coin, house_data.house());
     }
 
     /// House can withdraw the accumulated fees of the house object.
     public fun claim_fees(house_data: &mut HouseData, ctx: &mut TxContext) {
         // Only the house address can withdraw fee funds.
-        assert!(ctx.sender() == house(house_data), ECallerNotHouse);
+        assert!(ctx.sender() == house_data.house(), ECallerNotHouse);
 
         let total_fees = fees(house_data);
         let coin = coin::take(&mut house_data.fees, total_fees, ctx);
-        transfer::public_transfer(coin, house(house_data));
+        transfer::public_transfer(coin, house_data.house());
     }
 
     /// House can update the max stake. This allows larger stake to be placed.
     public fun update_max_stake(house_data: &mut HouseData, max_stake: u64, ctx: &mut TxContext) {
         // Only the house address can update the base fee.
-        assert!(ctx.sender() == house(house_data), ECallerNotHouse);
+        assert!(ctx.sender() == house_data.house(), ECallerNotHouse);
 
         house_data.max_stake = max_stake;
     }
@@ -115,7 +115,7 @@ module satoshi_flip::house_data {
     /// House can update the min stake. This allows smaller stake to be placed.
     public fun update_min_stake(house_data: &mut HouseData, min_stake: u64, ctx: &mut TxContext) {
         // Only the house address can update the min stake.
-        assert!(ctx.sender() == house(house_data), ECallerNotHouse);
+        assert!(ctx.sender() == house_data.house(), ECallerNotHouse);
 
         house_data.min_stake = min_stake;
     }

--- a/satoshi_flip/sources/house_data.move
+++ b/satoshi_flip/sources/house_data.move
@@ -6,23 +6,17 @@
 /// All games reside below the house as DoFs.
 module satoshi_flip::house_data {
 
-    use sui::object::{Self, UID};
     use sui::balance::{Self, Balance};
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
     use sui::package::{Self};
-    use sui::tx_context::{Self, TxContext};
-    use sui::transfer::{Self};
 
     // Error codes
     const ECallerNotHouse: u64 = 0;
     const EInsufficientBalance: u64 = 1;
 
-    friend satoshi_flip::single_player_satoshi;
-    friend satoshi_flip::mev_attack_resistant_single_player_satoshi;
-
     /// Configuration and Treasury object, managed by the house.
-    struct HouseData has key {
+    public struct HouseData has key {
         id: UID,
         balance: Balance<SUI>, // House's balance which also contains the acrued winnings of the house.
         house: address,
@@ -35,12 +29,12 @@ module satoshi_flip::house_data {
 
     /// A one-time use capability to initialize the house data; created and sent
     /// to sender in the initializer.
-    struct HouseCap has key {
+    public struct HouseCap has key {
         id: UID
     }
 
     /// Used as a one time witness to generate the publisher.
-    struct HOUSE_DATA has drop {}
+    public struct HOUSE_DATA has drop {}
 
     fun init(otw: HOUSE_DATA, ctx: &mut TxContext) {
         // Creating and sending the Publisher object to the sender.
@@ -51,7 +45,7 @@ module satoshi_flip::house_data {
             id: object::new(ctx)
         };
 
-        transfer::transfer(house_cap, tx_context::sender(ctx));
+        transfer::transfer(house_cap, ctx.sender());
     }
 
     // Functions
@@ -62,12 +56,12 @@ module satoshi_flip::house_data {
     /// Stores the house address and the base fee in basis points.
     /// This object is involed in all games created by the same instance of this package.
     public fun initialize_house_data(house_cap: HouseCap, coin: Coin<SUI>, public_key: vector<u8>, ctx: &mut TxContext) {
-        assert!(coin::value(&coin) > 0, EInsufficientBalance);
+        assert!(coin.value() > 0, EInsufficientBalance);
 
         let house_data = HouseData {
             id: object::new(ctx),
-            balance: coin::into_balance(coin),
-            house: tx_context::sender(ctx),
+            balance: coin.into_balance(),
+            house: ctx.sender(),
             public_key,
             max_stake: 50_000_000_000, // 50 SUI, 1 SUI = 10^9.
             min_stake: 1_000_000_000, // 1 SUI.
@@ -88,12 +82,12 @@ module satoshi_flip::house_data {
     }
 
     /// House can withdraw the entire balance of the house object.
-    /// Caution should be taken when calling this function. 
+    /// Caution should be taken when calling this function.
     /// If all funds are withdrawn, it will result in the house
     /// not being able to participate in any more games.
     public fun withdraw(house_data: &mut HouseData, ctx: &mut TxContext) {
         // Only the house address can withdraw funds.
-        assert!(tx_context::sender(ctx) == house(house_data), ECallerNotHouse);
+        assert!(ctx.sender() == house(house_data), ECallerNotHouse);
 
         let total_balance = balance(house_data);
         let coin = coin::take(&mut house_data.balance, total_balance, ctx);
@@ -103,7 +97,7 @@ module satoshi_flip::house_data {
     /// House can withdraw the accumulated fees of the house object.
     public fun claim_fees(house_data: &mut HouseData, ctx: &mut TxContext) {
         // Only the house address can withdraw fee funds.
-        assert!(tx_context::sender(ctx) == house(house_data), ECallerNotHouse);
+        assert!(ctx.sender() == house(house_data), ECallerNotHouse);
 
         let total_fees = fees(house_data);
         let coin = coin::take(&mut house_data.fees, total_fees, ctx);
@@ -113,7 +107,7 @@ module satoshi_flip::house_data {
     /// House can update the max stake. This allows larger stake to be placed.
     public fun update_max_stake(house_data: &mut HouseData, max_stake: u64, ctx: &mut TxContext) {
         // Only the house address can update the base fee.
-        assert!(tx_context::sender(ctx) == house(house_data), ECallerNotHouse);
+        assert!(ctx.sender() == house(house_data), ECallerNotHouse);
 
         house_data.max_stake = max_stake;
     }
@@ -121,7 +115,7 @@ module satoshi_flip::house_data {
     /// House can update the min stake. This allows smaller stake to be placed.
     public fun update_min_stake(house_data: &mut HouseData, min_stake: u64, ctx: &mut TxContext) {
         // Only the house address can update the min stake.
-        assert!(tx_context::sender(ctx) == house(house_data), ECallerNotHouse);
+        assert!(ctx.sender() == house(house_data), ECallerNotHouse);
 
         house_data.min_stake = min_stake;
     }
@@ -129,30 +123,30 @@ module satoshi_flip::house_data {
     // --------------- HouseData Mutations ---------------
 
     /// Returns a mutable reference to the balance of the house.
-    public(friend) fun borrow_balance_mut(house_data: &mut HouseData): &mut Balance<SUI> {
+    public(package) fun borrow_balance_mut(house_data: &mut HouseData): &mut Balance<SUI> {
         &mut house_data.balance
     }
 
     /// Returns a mutable reference to the fees of the house.
-    public(friend) fun borrow_fees_mut(house_data: &mut HouseData): &mut Balance<SUI> {
+    public(package) fun borrow_fees_mut(house_data: &mut HouseData): &mut Balance<SUI> {
         &mut house_data.fees
     }
 
     /// Returns a mutable reference to the house id.
-    public(friend) fun borrow_mut(house_data: &mut HouseData): &mut UID {
+    public(package) fun borrow_mut(house_data: &mut HouseData): &mut UID {
         &mut house_data.id
     }
 
     // --------------- HouseData Accessors ---------------
 
     /// Returns a reference to the house id.
-    public(friend) fun borrow(house_data: &HouseData): &UID {
+    public(package) fun borrow(house_data: &HouseData): &UID {
         &house_data.id
     }
 
     /// Returns the balance of the house.
     public fun balance(house_data: &HouseData): u64 {
-        balance::value(&house_data.balance)
+        house_data.balance.value()
     }
 
     /// Returns the address of the house.
@@ -177,7 +171,7 @@ module satoshi_flip::house_data {
 
     /// Returns the fees of the house.
     public fun fees(house_data: &HouseData): u64 {
-        balance::value(&house_data.fees)
+        house_data.fees.value()
     }
 
     /// Returns the base fee.

--- a/satoshi_flip/sources/single_player_satoshi.move
+++ b/satoshi_flip/sources/single_player_satoshi.move
@@ -6,25 +6,21 @@
 /// and the cancellation of games.
 module satoshi_flip::single_player_satoshi {
     // Imports
-    use std::string::{Self, String};
-    use std::vector;
+    use std::string::String;
 
     use sui::coin::{Self, Coin};
-    use sui::balance::{Self, Balance};
+    use sui::balance::Balance;
     use sui::sui::SUI;
     use sui::bls12381::bls12381_min_pk_verify;
-    use sui::object::{Self, UID, ID};
-    use sui::tx_context::{Self, TxContext};
-    use sui::transfer;
     use sui::event::emit;
     use sui::hash::{blake2b256};
     use sui::dynamic_object_field::{Self as dof};
 
     // Counter library
-    use satoshi_flip::counter_nft::{Self, Counter};
+    use satoshi_flip::counter_nft::Counter;
 
     // HouseData library
-    use satoshi_flip::house_data::{Self as hd, HouseData};
+    use satoshi_flip::house_data::HouseData;
 
     // Consts
     const EPOCHS_CANCEL_AFTER: u64 = 7;
@@ -47,7 +43,7 @@ module satoshi_flip::single_player_satoshi {
     // Events
 
     /// Emitted when a new game has started.
-    struct NewGame has copy, drop {
+    public struct NewGame has copy, drop {
         game_id: ID,
         player: address,
         vrf_input: vector<u8>,
@@ -57,7 +53,7 @@ module satoshi_flip::single_player_satoshi {
     }
 
     /// Emitted when a game has finished.
-    struct Outcome has copy, drop {
+    public struct Outcome has copy, drop {
         game_id: ID,
         status: u8
     }
@@ -66,7 +62,7 @@ module satoshi_flip::single_player_satoshi {
     // Represents a game and holds the acrued stake.
     // The guess field could have also been represented as a u8 or boolean, but we chose to use "H" and "T" strings for readability and safety.
     // Makes it easier for the user to assess if a selection they made on a DApp matches with the txn they are signing on their wallet.
-    struct Game has key, store {
+    public struct Game has key, store {
         id: UID,
         guess_placed_epoch: u64,
         total_stake: Balance<SUI>,
@@ -79,10 +75,10 @@ module satoshi_flip::single_player_satoshi {
     /// Function used to create a new game. The player must provide a guess and a Counter NFT.
     /// Stake is taken from the player's coin and added to the game's stake. The house's stake is also added to the game's stake.
     public fun start_game(guess: String, counter: &mut Counter, coin: Coin<SUI>, house_data: &mut HouseData, ctx: &mut TxContext): ID {
-        let fee_bp = hd::base_fee_in_bp(house_data);
+        let fee_bp = house_data.base_fee_in_bp();
         let (id, new_game) = internal_start_game(guess, counter, coin, house_data, fee_bp, ctx);
 
-        dof::add(hd::borrow_mut(house_data), id, new_game);
+        dof::add(house_data.borrow_mut(), id, new_game);
         id
     }
 
@@ -102,40 +98,40 @@ module satoshi_flip::single_player_satoshi {
         let Game {
             id,
             guess_placed_epoch: _,
-            total_stake,
+            mut total_stake,
             guess,
             player,
             vrf_input,
             fee_bp
-        } = dof::remove<ID, Game>(hd::borrow_mut(house_data), game_id);
+        } = dof::remove<ID, Game>(house_data.borrow_mut(), game_id);
 
         object::delete(id);
 
         // Step 1: Check the BLS signature, if its invalid abort.
-        let is_sig_valid = bls12381_min_pk_verify(&bls_sig, &hd::public_key(house_data), &vrf_input);
+        let is_sig_valid = bls12381_min_pk_verify(&bls_sig, &house_data.public_key(), &vrf_input);
         assert!(is_sig_valid, EInvalidBlsSig);
 
         // Hash the beacon before taking the 1st byte.
         let hashed_beacon = blake2b256(&bls_sig);
         // Step 2: Determine winner.
-        let first_byte = *vector::borrow(&hashed_beacon, 0);
+        let first_byte = hashed_beacon[0];
         let player_won = map_guess(guess) == (first_byte % 2);
 
         // Step 3: Distribute funds based on result.
         let status = if (player_won) {
             // Step 3.a: If player wins transfer the game balance as a coin to the player.
             // Calculate the fee and transfer it to the house.
-            let stake_amount = balance::value(&total_stake);
+            let stake_amount = total_stake.value();
             let fee_amount = fee_amount(stake_amount, fee_bp);
-            let fees = balance::split(&mut total_stake, fee_amount);
-            balance::join(hd::borrow_fees_mut(house_data), fees);
+            let fees = total_stake.split(fee_amount);
+            house_data.borrow_fees_mut().join(fees);
 
             // Calculate the rewards and take it from the game stake.
-            transfer::public_transfer(coin::from_balance(total_stake, ctx), player);
+            transfer::public_transfer(total_stake.into_coin(ctx), player);
             PLAYER_WON_STATE
         } else {
             // Step 3.b: If house wins, then add the game stake to the house_data.house_balance (no fees are taken).
-            balance::join(hd::borrow_balance_mut(house_data), total_stake);
+            house_data.borrow_balance_mut().join(total_stake);
             HOUSE_WON_STATE
         };
 
@@ -159,16 +155,16 @@ module satoshi_flip::single_player_satoshi {
             player,
             vrf_input: _,
             fee_bp: _
-        } = dof::remove(hd::borrow_mut(house_data), game_id);
+        } = dof::remove(house_data.borrow_mut(), game_id);
 
         object::delete(id);
 
-        let caller_epoch = tx_context::epoch(ctx);
+        let caller_epoch = ctx.epoch();
         let cancel_epoch = guess_placed_epoch + EPOCHS_CANCEL_AFTER;
         // Ensure that minimum epochs have passed before user can cancel.
         assert!(cancel_epoch <= caller_epoch, ECanNotChallengeYet);
 
-        transfer::public_transfer(coin::from_balance(total_stake, ctx), player);
+        transfer::public_transfer(total_stake.into_coin(ctx), player);
 
         emit(Outcome {
             game_id,
@@ -185,7 +181,7 @@ module satoshi_flip::single_player_satoshi {
 
     /// Returns the total stake.
     public fun stake(game: &Game): u64 {
-        balance::value(&game.total_stake)
+        game.total_stake.value()
     }
 
     /// Returns the player's guess.
@@ -218,55 +214,55 @@ module satoshi_flip::single_player_satoshi {
 
     /// Helper function to check if a game exists.
     public fun game_exists(house_data: &HouseData, game_id: ID): bool {
-        dof::exists_(hd::borrow(house_data), game_id)
+        dof::exists_(house_data.borrow(), game_id)
     }
 
     /// Helper function to check that a game exists and return a reference to the game Object.
     /// Can be used in combination with any accessor to retrieve the desired game field.
     public fun borrow_game(game_id: ID, house_data: &HouseData): &Game {
         assert!(game_exists(house_data, game_id), EGameDoesNotExist);
-        dof::borrow(hd::borrow(house_data), game_id)
+        dof::borrow(house_data.borrow(), game_id)
     }
 
     // --------------- Internal Helper functions ---------------
 
-    /// Internal helper function used to create a new game. 
+    /// Internal helper function used to create a new game.
     /// The player must provide a guess and a Counter NFT.
-    /// Stake is taken from the player's coin and added to the game's stake. 
+    /// Stake is taken from the player's coin and added to the game's stake.
     /// The house's stake is also added to the game's stake.
     fun internal_start_game(guess: String, counter: &mut Counter, coin: Coin<SUI>, house_data: &mut HouseData, fee_bp: u16, ctx: &mut TxContext): (ID, Game) {
         // Ensure guess is valid.
         map_guess(guess);
-        let user_stake = coin::value(&coin);
+        let user_stake = coin.value();
         // Ensure that the stake is not higher than the max stake.
-        assert!(user_stake <= hd::max_stake(house_data), EStakeTooHigh);
+        assert!(user_stake <= house_data.max_stake(), EStakeTooHigh);
         // Ensure that the stake is not lower than the min stake.
-        assert!(user_stake >= hd::min_stake(house_data), EStakeTooLow);
+        assert!(user_stake >= house_data.min_stake(), EStakeTooLow);
         // Ensure that the house has enough balance to play for this game.
-        assert!(hd::balance(house_data) >= user_stake, EInsufficientHouseBalance);
+        assert!(house_data.balance() >= user_stake, EInsufficientHouseBalance);
 
         // Get the house's stake.
-        let total_stake = balance::split(hd::borrow_balance_mut(house_data), user_stake);
+        let mut total_stake = house_data.borrow_balance_mut().split(user_stake);
         coin::put(&mut total_stake, coin);
 
-        let vrf_input = counter_nft::get_vrf_input_and_increment(counter);
+        let vrf_input = counter.get_vrf_input_and_increment();
 
         let id = object::new(ctx);
         let game_id = object::uid_to_inner(&id);
 
         let new_game = Game {
             id,
-            guess_placed_epoch: tx_context::epoch(ctx),
+            guess_placed_epoch: ctx.epoch(),
             total_stake,
             guess,
-            player: tx_context::sender(ctx),
+            player: ctx.sender(),
             vrf_input,
             fee_bp
         };
 
         emit(NewGame {
             game_id,
-            player: tx_context::sender(ctx),
+            player: ctx.sender(),
             vrf_input,
             guess,
             user_stake,
@@ -280,9 +276,11 @@ module satoshi_flip::single_player_satoshi {
     /// H = 0
     /// T = 1
     fun map_guess(guess: String): u8 {
-        assert!(string::bytes(&guess) == &HEADS || string::bytes(&guess) == &TAILS, EInvalidGuess);
+    	let heads = HEADS;
+    	let tails = TAILS;
+        assert!(guess.bytes() == heads || guess.bytes() == tails, EInvalidGuess);
 
-        if (string::bytes(&guess) == &HEADS) {
+        if (guess.bytes() == heads) {
             0
         } else {
             1

--- a/satoshi_flip/sources/single_player_satoshi.move
+++ b/satoshi_flip/sources/single_player_satoshi.move
@@ -248,7 +248,7 @@ module satoshi_flip::single_player_satoshi {
         let vrf_input = counter.get_vrf_input_and_increment();
 
         let id = object::new(ctx);
-        let game_id = object::uid_to_inner(&id);
+        let game_id = id.to_inner();
 
         let new_game = Game {
             id,

--- a/satoshi_flip/tests/test_counter_nft.move
+++ b/satoshi_flip/tests/test_counter_nft.move
@@ -17,71 +17,68 @@ module satoshi_flip::test_counter_nft {
 
     #[test]
     fun creates_counter_nft() {
-        let scenario_val = test_scenario::begin(USER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(USER);
 
         // Mint a counter NFT for USER.
         {
-            let ctx = test_scenario::ctx(scenario);
+            let ctx = scenario.ctx();
             let counter = counter_nft::mint(ctx);
-            counter_nft::transfer_to_sender(counter, ctx);
+            counter.transfer_to_sender(ctx);
         };
 
         // Check that the initial count value is 0.
-        test_scenario::next_tx(scenario, USER);
+        scenario.next_tx(USER);
         {
-            let counter_nft = test_scenario::take_from_sender<Counter>(scenario);
-            assert!(counter_nft::count(&counter_nft) == 0, EInvalidCountOnNewCounter);
-            test_scenario::return_to_sender(scenario, counter_nft);
+            let counter_nft = scenario.take_from_sender<Counter>();
+            assert!(counter_nft.count() == 0, EInvalidCountOnNewCounter);
+            scenario.return_to_sender(counter_nft);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun increments_counter_nft() {
-        let scenario_val = test_scenario::begin(USER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(USER);
 
         // Mint a counter NFT for USER.
         {
-            let ctx = test_scenario::ctx(scenario);
+            let ctx = scenario.ctx();
             let counter = counter_nft::mint(ctx);
-            counter_nft::transfer_to_sender(counter, ctx);
+            counter.transfer_to_sender(ctx);
         };
 
         // Increment it & check its value has increased.
-        test_scenario::next_tx(scenario, USER);
+        scenario.next_tx(USER);
         {
-            let counter_nft = test_scenario::take_from_sender<Counter>(scenario);
-            counter_nft::get_vrf_input_and_increment(&mut counter_nft);
-            assert!(counter_nft::count(&counter_nft) == 1, EInvalidCountOnIncreasedCounter);
-            test_scenario::return_to_sender(scenario, counter_nft);
+            let mut counter_nft = scenario.take_from_sender<Counter>();
+            counter_nft.get_vrf_input_and_increment();
+            assert!(counter_nft.count() == 1, EInvalidCountOnIncreasedCounter);
+            scenario.return_to_sender(counter_nft);
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun burns_counter_nft() {
-        let scenario_val = test_scenario::begin(USER);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(USER);
 
        // Mint a counter NFT for USER.
         {
-            let ctx = test_scenario::ctx(scenario);
+            let ctx = scenario.ctx();
             let counter = counter_nft::mint(ctx);
-            counter_nft::transfer_to_sender(counter, ctx);
+            counter.transfer_to_sender(ctx);
         };
 
         // Burn the NFT.
-        test_scenario::next_tx(scenario, USER);
+        scenario.next_tx(USER);
         {
-            let counter_nft = test_scenario::take_from_sender<Counter>(scenario);
-            counter_nft::burn_for_testing(counter_nft);
+            let counter_nft = scenario.take_from_sender<Counter>();
+            counter_nft.burn_for_testing();
         };
 
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
 }


### PR DESCRIPTION
This migrates the example to Move 2024 Beta.

Testing was done in two ways:

1. Comparing the bytecode before and after migration for the main code (no change)
2. Migrating the tests to Move 2024, and ensuring they still run

Careful review would be appreciated here.