### PR TITLE
refactor(map_guess): Prefer as_bytes() over bytes() for string compar…

### DIFF
--- a/satoshi_flip/Move.toml
+++ b/satoshi_flip/Move.toml
@@ -4,7 +4,6 @@ version = "0.0.1"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
 
 [addresses]
 satoshi_flip = "0x0"

--- a/satoshi_flip/sources/mev_attack_resistant_single_player_satoshi.move
+++ b/satoshi_flip/sources/mev_attack_resistant_single_player_satoshi.move
@@ -305,9 +305,9 @@ module satoshi_flip::mev_attack_resistant_single_player_satoshi {
     fun map_guess(guess: String): u8 {
     	let heads = HEADS;
     	let tails = TAILS;
-        assert!(guess.bytes() == heads|| guess.bytes() == tails, EInvalidGuess);
+        assert!(guess.as_bytes() == heads|| guess.as_bytes() == tails, EInvalidGuess);
 
-        if (guess.bytes() == heads) {
+        if (guess.as_bytes() == heads) {
             0
         } else {
             1

--- a/satoshi_flip/sources/single_player_satoshi.move
+++ b/satoshi_flip/sources/single_player_satoshi.move
@@ -278,9 +278,9 @@ module satoshi_flip::single_player_satoshi {
     fun map_guess(guess: String): u8 {
     	let heads = HEADS;
     	let tails = TAILS;
-        assert!(guess.bytes() == heads || guess.bytes() == tails, EInvalidGuess);
+        assert!(guess.as_bytes() == heads || guess.as_bytes() == tails, EInvalidGuess);
 
-        if (guess.bytes() == heads) {
+        if (guess.as_bytes() == heads) {
             0
         } else {
             1


### PR DESCRIPTION
**Refactor: Use `as_bytes()` instead of `bytes()` in `map_guess`**

**Description:**

This PR modifies the internal helper function `map_guess` within the `single_player_satoshi` module.

**Changes:**

* Replaced the two instances of `guess.bytes()` with `guess.as_bytes()` when comparing the input `guess` string to the `HEADS` and `TAILS` constants.

I also removed sui dependencies because it is already default in later versions.